### PR TITLE
Fixed condition where typewriteComplete would never fire.

### DIFF
--- a/src/typewrite.js
+++ b/src/typewrite.js
@@ -81,6 +81,7 @@
             // changes the typing speed
             if(Object.keys(element)[0] === 'speed'){
                 settings.speed = 1000 / element.speed;
+	        settings.queue = settings.queue - 1;
             }
 
             // removes characters


### PR DESCRIPTION
The {speed: X} action doesn't decrement 1 from the queue, so typewriteComplete would never fire. Fixed this bug (Which you already made progress on fixing - Thanks).